### PR TITLE
Fix invalid license in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -15,6 +15,6 @@
     "Intl::LanguageTaggish": "lib/Intl/LanguageTaggish.rakumod"
   },
   "resources": [],
-  "license": "Artist-2.0",
+  "license": "Artistic-2.0",
   "source-url": "git://github.com/alabamenhu/IntlLanguageTaggish.git"
 }


### PR DESCRIPTION
The license field should be a valid SPDX identifier as mentioned under https://docs.raku.org/language/modules#Preparing_the_module